### PR TITLE
Rename onError to avoid name clash.

### DIFF
--- a/src/Twine/Guard.hs
+++ b/src/Twine/Guard.hs
@@ -26,7 +26,7 @@ data TerminationAction =
 data TerminationHandler e =
   TerminationHandler {
       onExplosion :: SomeException -> IO TerminationAction
-    , onError :: e -> IO TerminationAction
+    , onErr :: e -> IO TerminationAction
     , onGraceful :: IO TerminationAction
     }
 
@@ -61,7 +61,7 @@ data TerminationHandler e =
 --
 guarded :: TerminationHandler e -> EitherT e IO () -> IO ()
 guarded handler action =
-  let run = runEitherT action >>= either (onError handler) (const . onGraceful $ handler)
+  let run = runEitherT action >>= either (onErr handler) (const . onGraceful $ handler)
       safe = run `catchAll` onExplosion handler `catchAll` (const . pure) Restart
    in safe >>= \a -> when (a == Restart) $ guarded handler action
 

--- a/test/Test/IO/Twine/Guard.hs
+++ b/test/Test/IO/Twine/Guard.hs
@@ -26,7 +26,7 @@ data HResult =
 
 handler v = TerminationHandler {
     onExplosion = const $ putMVar v HExplosion >> pure Die
-  , onError = \t -> putMVar v (HError t) >> pure Die
+  , onErr = \t -> putMVar v (HError t) >> pure Die
   , onGraceful = putMVar v HGraceful >> pure Die
   }
 


### PR DESCRIPTION
With Control.Monad.Catch.onError.